### PR TITLE
Replaced use of removed ValueCollector with VarCloner

### DIFF
--- a/src/DataCollector/EventCollector.php
+++ b/src/DataCollector/EventCollector.php
@@ -4,7 +4,7 @@ namespace Barryvdh\Debugbar\DataCollector;
 use DebugBar\DataCollector\TimeDataCollector;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Support\Str;
-use Symfony\Component\HttpKernel\DataCollector\Util\ValueExporter;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 class EventCollector extends TimeDataCollector
 {
@@ -18,7 +18,7 @@ class EventCollector extends TimeDataCollector
     {
         parent::__construct($requestStartTime);
 
-        $this->exporter = new ValueExporter();
+        $this->exporter = new VarCloner();
     }
 
     public function onWildcardEvent($name = null, $data = [])
@@ -76,7 +76,7 @@ class EventCollector extends TimeDataCollector
             if (is_object($value) && Str::is('Illuminate\*\Events\*', get_class($value))) {
                 $value =  $this->prepareParams(get_object_vars($value));
             }
-            $data[$key] = htmlentities($this->exporter->exportValue($value), ENT_QUOTES, 'UTF-8', false);
+            $data[$key] = htmlentities($this->exporter->cloneVar($value), ENT_QUOTES, 'UTF-8', false);
         }
 
         return $data;


### PR DESCRIPTION
As per L5.6, Symfony 4 is now used.  As such, VarCloner must be used in place of ValueCollector.

Builds on commit b5d1df3 & #784